### PR TITLE
combine covr & lintr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,7 @@ r:
  - oldrel
  - release
  - devel
+
+r_github_packages: jimhester/covr
+
+after_success: Rscript -e 'covr::codecov()'

--- a/R/camelCase.R
+++ b/R/camelCase.R
@@ -10,4 +10,4 @@
 #' camelCase()
 #'
 #' @export
-camelCase = function() return("cool")
+camelCase <- function() return("cool")

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 [![Build Status](https://travis-ci.org/mschilli87/testCovrVsLintr.svg?branch=master)](https://travis-ci.org/mschilli87/testCovrVsLintr)
+[![codecov](https://codecov.io/gh/mschilli87/testCovrVsLintr/branch/master/graph/badge.svg)](https://codecov.io/gh/mschilli87/testCovrVsLintr)
 # testCovrVsLintr
 Minimal R package demonstrating https://github.com/jimhester/covr/issues/253


### PR DESCRIPTION
This *should* work as the only difference between this and #1 is faa5be722f3d345e6d18c7aa8e2c9faa077bc910.

But I suspect it will fail due to https://github.com/jimhester/covr/issues/253.

---
expected **unintended** `lintr` output:

```
tests/testthat.R:2:9: style: Variable and function names should be all lowercase.
library(testCovrVsLintr)
        ^~~~~~~~~~~~~~~
tests/testthat/test-camelCase.R:1:9: style: Variable and function names should be all lowercase.
library(testCovrVsLintr)
        ^~~~~~~~~~~~~~~
```