### PR TITLE
combining covr with lintr with copied .lintr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,7 @@ r:
  - oldrel
  - release
  - devel
+
+r_github_packages: jimhester/covr
+
+after_success: Rscript -e 'covr::codecov()'

--- a/R/camelCase.R
+++ b/R/camelCase.R
@@ -10,4 +10,4 @@
 #' camelCase()
 #'
 #' @export
-camelCase = function() return("cool")
+camelCase <- function() return("cool")

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 [![Build Status](https://travis-ci.org/mschilli87/testCovrVsLintr.svg?branch=master)](https://travis-ci.org/mschilli87/testCovrVsLintr)
+[![codecov](https://codecov.io/gh/mschilli87/testCovrVsLintr/branch/master/graph/badge.svg)](https://codecov.io/gh/mschilli87/testCovrVsLintr)
 # testCovrVsLintr
 Minimal R package demonstrating https://github.com/jimhester/covr/issues/253


### PR DESCRIPTION
This should *finally* work.

---
Unfortunately, as moving the `.lintr` file broke linting during `R CMD check` (see 770f4a64980f4f1c27fd244799aeb37ecd178527), this means **two identical copies** of the `lintr` configuartion file  (`.lintr` & and `inst/.lintr`) need to be maintained for this solution.